### PR TITLE
Update prefs for sprint 22

### DIFF
--- a/main.js
+++ b/main.js
@@ -335,7 +335,7 @@ define(function (require, exports, module) {
     function init() {
         var $shortcutsPanel,
             $shortcutsContent,
-            prefs   = PreferencesManager.getPreferenceStorage(module.id, defaultPrefs),
+            prefs   = PreferencesManager.getPreferenceStorage(module, defaultPrefs),
             height  = prefs.getValue("height"),
             s,
             view_menu;


### PR DESCRIPTION
This pull request updates preferences for changes made in Sprint 22.

I decided to _not_ migrate old preferences. This extension previously stored all prefs using module.id which is "main", so there is likely a conflict with other extensions. The only preference is "height" of bottom panel, which changes a lot anyway, so I think it's best to skip the migration.
