### PR TITLE
Removed unnecessary comment

### DIFF
--- a/nls/de/strings.js
+++ b/nls/de/strings.js
@@ -21,8 +21,6 @@
  * 
  */
 
-// English - root strings
-
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
 

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -21,8 +21,6 @@
  * 
  */
 
-// English - root strings
-
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
 /*global define */
 


### PR DESCRIPTION
Sorry, I introduced this comment, but we should remove it so the file can be easily copied on creating new translations.
