### PR TITLE
Remove unused reference to PreferencesManager

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,7 +36,6 @@ define(function (require, exports, module) {
         KeyBindingManager   = brackets.getModule("command/KeyBindingManager"),
         Menus               = brackets.getModule("command/Menus"),
         PanelManager        = brackets.getModule("view/PanelManager"),
-        PreferencesManager  = brackets.getModule("preferences/PreferencesManager"),
         Strings             = require("strings");
 
     var panelHtml           = require("text!templates/bottom-panel.html"),


### PR DESCRIPTION
I was planning to remove deprecated preferences code, but there wasn't any :)
