### PR TITLE
Add context menu with override and disable commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Button to "Copy to Current Document" inserts Table HTML markup at the current se
 
 Type the name of the command you're looking for in the filter field to find the shortcut faster.
 
+Use *Override Shortcut* and *Disable Shortcuts* commands from context (right-click) menu to facilitate [editing of keymap.json file](https://github.com/adobe/brackets/wiki/User-Key-Bindings).
+
 ## License
 
 MIT-licensed -- see _main.js_ for details.

--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -28,6 +28,10 @@ define({
     //Menu
     "MENU_SHOW_SHORTCUTS"                       : "Show Shortcuts",
     
+    // Context Menu
+    "CMENU_OVERRIDE"                            : "Override Shortcut",
+    "CMENU_DISABLE"                             : "Disable Shortcut",
+    
     //Table
     "TABLE_BASE_KEY"                            : "Base Key",
     "TABLE_KEY_BINDING"                         : "Key Binding",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
     "name": "brackets-display-shortcuts",
     "title": "Display Shortcuts",
-    "version": "1.2.2",
-    "description": "Display current shortcuts in a bottom panel that can be sorted and filtered.",
+    "version": "1.3.0",
+    "description": "Display current shortcuts in a bottom panel that can be sorted and filtered. Override and disable shortcuts from context menu.",
     "homepage": "https://github.com/redmunds/brackets-display-shortcuts",
     "author": "Randy Edmunds (https://github.com/redmunds)",
     "license": "MIT",
     "categories": "utility",
     "keywords": [
-        "shortcuts", "bindings"
+        "shortcuts", "bindings", "keybindings", "commands"
     ],
     "engines": {
         "brackets": ">=0.44.0"

--- a/templates/shortcut-table.html
+++ b/templates/shortcut-table.html
@@ -11,9 +11,9 @@
     <tbody>
         {{#keyList}}
             {{#filterMatch}}
-                <tr>
+                <tr data-commandid="{{commandID}}" data-keybinding="{{keyBinding}}">
                     <td class="shortcut-base">{{keyBase}}</td>
-                    <td class="shortcut-binding">{{keyBinding}}</td>
+                    <td class="shortcut-binding">{{keyBindingDisplay}}</td>
                     <td class="shortcut-cmd-id">{{commandID}}</td>
                     <td class="shortcut-cmd-name">{{commandName}}</td>
                     <td class="shortcut-orig">{{origin}}</td>


### PR DESCRIPTION
This adds a context menu with *Override Shortcut* and *Disable Shortcuts* commands to facilitate [editing of keymap.json file](https://github.com/adobe/brackets/wiki/User-Key-Bindings).
