### PR TITLE
Fix copy button

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,15 +30,17 @@ define(function (require, exports, module) {
     
     // Brackets modules
     var _                   = brackets.getModule("thirdparty/lodash"),
-        Commands            = brackets.getModule("command/Commands"),
+        CodeMirror          = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
         CommandManager      = brackets.getModule("command/CommandManager"),
+        Commands            = brackets.getModule("command/Commands"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),
         EditorManager       = brackets.getModule("editor/EditorManager"),
         ExtensionUtils      = brackets.getModule("utils/ExtensionUtils"),
         KeyBindingManager   = brackets.getModule("command/KeyBindingManager"),
+        MainViewManager     = brackets.getModule("view/MainViewManager"),
         Menus               = brackets.getModule("command/Menus"),
-        WorkspaceManager    = brackets.getModule("view/WorkspaceManager"),
         StringUtils         = brackets.getModule("utils/StringUtils"),
+        WorkspaceManager    = brackets.getModule("view/WorkspaceManager"),
         Strings             = require("strings");
 
     var panelHtml           = require("text!templates/bottom-panel.html"),
@@ -378,7 +380,7 @@ define(function (require, exports, module) {
             _clearSortingEventHandlers();
             panel.hide();
             CommandManager.get(TOGGLE_SHORTCUTS_ID).setChecked(false);
-            EditorManager.focusEditor();
+            MainViewManager.focusActivePane();
         } else {
             panel.show();
             CommandManager.get(TOGGLE_SHORTCUTS_ID).setChecked(true);
@@ -386,7 +388,7 @@ define(function (require, exports, module) {
             initKeyList();
             _showShortcuts();
         }
-        EditorManager.resizeEditor();
+        WorkspaceManager.recomputeLayout();
     }
 
     function _insertShortcutTemplate(contextCmd, doc) {

--- a/main.js
+++ b/main.js
@@ -537,7 +537,7 @@ define(function (require, exports, module) {
             }
         });
 
-        $shortcutsPanel.find(".copy-table").click(_copyTableToCurrentDoc());
+        $shortcutsPanel.find(".copy-table").click(_copyTableToCurrentDoc);
 
         $shortcutsPanel.find(".close").click(function () {
             CommandManager.execute(TOGGLE_SHORTCUTS_ID);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "brackets-display-shortcuts",
     "title": "Display Shortcuts",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "description": "Display current shortcuts in a bottom panel that can be sorted and filtered. Add and disable shortcuts from context menu.",
     "homepage": "https://github.com/redmunds/brackets-display-shortcuts",
     "author": "Randy Edmunds (https://github.com/redmunds)",


### PR DESCRIPTION
Fix copy button for https://github.com/redmunds/brackets-display-shortcuts/issues/51.

This was broken in https://github.com/redmunds/brackets-display-shortcuts/commit/7c734898afa65fc1a381f48f0c44a6da8b0b7d23.

Also remove calls to deprecated APIs.