### PR TITLE
Use thirdparty/mustache instead of global Mustache

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@
 
 
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4, maxerr: 50 */
-/*global define, brackets, $, Mustache, CodeMirror, _showShortcuts, window */
+/*global define, brackets, $, CodeMirror, _showShortcuts, window */
 
 define(function (require, exports, module) {
     "use strict";
@@ -39,6 +39,7 @@ define(function (require, exports, module) {
         KeyBindingManager   = brackets.getModule("command/KeyBindingManager"),
         MainViewManager     = brackets.getModule("view/MainViewManager"),
         Menus               = brackets.getModule("command/Menus"),
+        Mustache            = brackets.getModule("thirdparty/mustache/mustache"),
         StringUtils         = brackets.getModule("utils/StringUtils"),
         WorkspaceManager    = brackets.getModule("view/WorkspaceManager"),
         Strings             = require("strings");


### PR DESCRIPTION
This PR fixes an deprecation warning by using thirdparty/mustache instead of the global Mustache.

```  js
Use brackets.getModule("thirdparty/mustache/mustache") instead of global Mustache.
    at Object.defineProperty.get (file:///C:/Program%20Files%20(x86)/Brackets/dev/src/brackets.js:123:32)
    at init (file:///C:/Users/Pete/AppData/Roaming/Brackets/extensions/user/brackets-display-shortcuts/main.js:514:13)
    at Object.<anonymous> (file:///C:/Users/Pete/AppData/Roaming/Brackets/extensions/user/brackets-display-shortcuts/main.js:552:5)
    at Object.context.execCb (file:///C:/Program%20Files%20(x86)
```